### PR TITLE
feat(ui): add reusable component library and utility, drop unused modals

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -48,20 +48,6 @@ export default function RootLayout() {
             animation: 'slide_from_bottom',
           }}
         />
-        <Stack.Screen
-          name="transaction/[id]"
-          options={{
-            headerShown: false,
-            presentation: 'modal',
-          }}
-        />
-        <Stack.Screen
-          name="category-select"
-          options={{
-            headerShown: false,
-            presentation: 'modal',
-          }}
-        />
       </Stack>
     </SafeAreaProvider>
   );

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { TouchableOpacity, Text, ActivityIndicator, View } from 'react-native';
+import { cn } from '../../utils/cn';
+
+interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+  size?: 'sm' | 'md' | 'lg';
+  children: React.ReactNode;
+  onPress?: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  children,
+  onPress,
+  loading = false,
+  disabled = false,
+  icon,
+  className,
+}: ButtonProps) => {
+  const isDisabled = disabled || loading;
+
+  const baseStyles = 'flex-row items-center justify-center rounded-lg';
+
+  const variantStyles = {
+    primary: 'bg-gray-800 active:bg-gray-900',
+    secondary: 'bg-gray-100 active:bg-gray-200',
+    ghost: 'bg-transparent active:bg-gray-100',
+    danger: 'bg-red-500 active:bg-red-600',
+  };
+
+  const disabledVariantStyles = {
+    primary: 'bg-gray-300',
+    secondary: 'bg-gray-100',
+    ghost: 'bg-transparent',
+    danger: 'bg-red-300',
+  };
+
+  const sizeStyles = {
+    sm: 'px-3 py-2 min-h-[32px]',
+    md: 'px-4 py-3 min-h-[44px]',
+    lg: 'px-6 py-4 min-h-[52px]',
+  };
+
+  const textVariantStyles = {
+    primary: 'text-white font-medium',
+    secondary: 'text-gray-700 font-medium',
+    ghost: 'text-gray-600 font-medium',
+    danger: 'text-white font-medium',
+  };
+
+  const disabledTextVariantStyles = {
+    primary: 'text-gray-500',
+    secondary: 'text-gray-400',
+    ghost: 'text-gray-400',
+    danger: 'text-red-200',
+  };
+
+  const textSizeStyles = {
+    sm: 'text-sm',
+    md: 'text-base',
+    lg: 'text-lg',
+  };
+
+  const spinnerColors = {
+    primary: '#ffffff',
+    secondary: '#374151',
+    ghost: '#6b7280',
+    danger: '#ffffff',
+  };
+
+  const disabledSpinnerColors = {
+    primary: '#6b7280',
+    secondary: '#9ca3af',
+    ghost: '#9ca3af',
+    danger: '#fca5a5',
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={isDisabled}
+      className={cn(
+        baseStyles,
+        sizeStyles[size],
+        isDisabled ? disabledVariantStyles[variant] : variantStyles[variant],
+        isDisabled && 'opacity-60',
+        className
+      )}
+      activeOpacity={0.8}>
+      {loading && (
+        <ActivityIndicator
+          size="small"
+          color={isDisabled ? disabledSpinnerColors[variant] : spinnerColors[variant]}
+          className="mr-2"
+        />
+      )}
+
+      {icon && !loading && <View className="mr-2">{icon}</View>}
+
+      <Text
+        className={cn(
+          textSizeStyles[size],
+          isDisabled ? disabledTextVariantStyles[variant] : textVariantStyles[variant]
+        )}>
+        {children}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+export default Button;

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import { cn } from '../../utils/cn';
+
+interface CardProps {
+  variant?: 'default' | 'elevated' | 'bordered';
+  padding?: 'sm' | 'md' | 'lg';
+  children: React.ReactNode;
+  onPress?: () => void;
+  className?: string;
+}
+
+const Card: React.FC<CardProps> = ({
+  variant = 'default',
+  padding = 'md',
+  children,
+  onPress,
+  className,
+}) => {
+  const baseStyles = 'bg-white rounded-xl';
+
+  const variantStyles = {
+    default: '',
+    elevated: 'shadow-md',
+    bordered: 'border border-gray-200',
+  };
+
+  const paddingStyles = {
+    sm: 'p-3',
+    md: 'p-4',
+    lg: 'p-6',
+  };
+
+  const combinedClassName = cn(
+    baseStyles,
+    variantStyles[variant],
+    paddingStyles[padding],
+    className
+  );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity onPress={onPress} className={combinedClassName} activeOpacity={0.95}>
+        {children}
+      </TouchableOpacity>
+    );
+  }
+
+  return <View className={combinedClassName}>{children}</View>;
+};
+
+export default Card;

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { View, TextInput, Text, TextInputProps } from 'react-native';
+import { cn } from '../../utils/cn';
+
+interface InputProps extends Omit<TextInputProps, 'className'> {
+  label?: string;
+  error?: string;
+  hint?: string;
+  className?: string;
+  inputClassName?: string;
+}
+
+const Input: React.FC<InputProps> = ({
+  label,
+  error,
+  hint,
+  className,
+  inputClassName,
+  onFocus,
+  onBlur,
+  ...props
+}) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleFocus = (e: any) => {
+    setIsFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur = (e: any) => {
+    setIsFocused(false);
+    onBlur?.(e);
+  };
+
+  const baseInputStyles = 'px-4 py-3 rounded-lg text-base text-gray-900 min-h-[44px]';
+
+  const inputStateStyles = error
+    ? 'bg-red-50 border border-red-500'
+    : isFocused
+      ? 'bg-white border border-gray-400'
+      : 'bg-gray-50 border border-gray-200';
+
+  return (
+    <View className={cn('w-full', className)}>
+      {label && <Text className="mb-2 text-sm font-medium text-gray-700">{label}</Text>}
+
+      <TextInput
+        {...props}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        className={cn(baseInputStyles, inputStateStyles, inputClassName)}
+        placeholderTextColor="#9ca3af"
+      />
+
+      {error && <Text className="mt-1 text-sm text-red-600">{error}</Text>}
+
+      {hint && !error && <Text className="mt-1 text-sm text-gray-500">{hint}</Text>}
+    </View>
+  );
+};
+
+export default Input;

--- a/components/ui/Typography.tsx
+++ b/components/ui/Typography.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { cn } from '../../utils/cn';
+
+interface TypographyProps {
+  variant?: 'h1' | 'h2' | 'h3' | 'body' | 'caption' | 'overline';
+  color?: 'primary' | 'secondary' | 'muted' | 'success' | 'error';
+  weight?: 'normal' | 'medium' | 'semibold' | 'bold';
+  children: React.ReactNode;
+  className?: string;
+}
+
+const Typography: React.FC<TypographyProps> = ({
+  variant = 'body',
+  color = 'primary',
+  weight = 'normal',
+  children,
+  className,
+}) => {
+  const variantStyles = {
+    h1: 'text-4xl leading-10',
+    h2: 'text-3xl leading-9',
+    h3: 'text-2xl leading-8',
+    body: 'text-base leading-6',
+    caption: 'text-sm leading-5',
+    overline: 'text-xs leading-4 uppercase tracking-wide',
+  };
+
+  const colorStyles = {
+    primary: 'text-gray-900',
+    secondary: 'text-gray-600',
+    muted: 'text-gray-400',
+    success: 'text-green-600',
+    error: 'text-red-600',
+  };
+
+  const weightStyles = {
+    normal: 'font-normal',
+    medium: 'font-medium',
+    semibold: 'font-semibold',
+    bold: 'font-bold',
+  };
+
+  return (
+    <Text
+      className={cn(variantStyles[variant], colorStyles[color], weightStyles[weight], className)}>
+      {children}
+    </Text>
+  );
+};
+
+export const Heading1: React.FC<Omit<TypographyProps, 'variant'>> = (props) => (
+  <Typography {...props} variant="h1" weight="bold" />
+);
+
+export const Heading2: React.FC<Omit<TypographyProps, 'variant'>> = (props) => (
+  <Typography {...props} variant="h2" weight="semibold" />
+);
+
+export const Heading3: React.FC<Omit<TypographyProps, 'variant'>> = (props) => (
+  <Typography {...props} variant="h3" weight="semibold" />
+);
+
+export const BodyText: React.FC<Omit<TypographyProps, 'variant'>> = (props) => (
+  <Typography {...props} variant="body" />
+);
+
+export const Caption: React.FC<Omit<TypographyProps, 'variant'>> = (props) => (
+  <Typography {...props} variant="caption" color="secondary" />
+);
+
+export const Overline: React.FC<Omit<TypographyProps, 'variant'>> = (props) => (
+  <Typography {...props} variant="overline" color="muted" weight="medium" />
+);
+
+export default Typography;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,110 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./App.{js,ts,tsx}', './components/**/*.{js,ts,tsx}', './app/**/*.{js,ts,tsx}'],
-
   presets: [require('nativewind/preset')],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        gray: {
+          25: '#fcfcfd',
+          50: '#f8fafc',
+          100: '#f1f5f9',
+          200: '#e2e8f0',
+          300: '#cbd5e1',
+          400: '#94a3b8',
+          500: '#64748b',
+          600: '#475569',
+          700: '#334155',
+          800: '#1e293b',
+          900: '#0f172a',
+          950: '#020617',
+        },
+
+        success: {
+          50: '#f0fdf4',
+          500: '#22c55e',
+          600: '#16a34a',
+        },
+        error: {
+          50: '#fef2f2',
+          500: '#ef4444',
+          600: '#dc2626',
+        },
+        warning: {
+          50: '#fffbeb',
+          500: '#f59e0b',
+          600: '#d97706',
+        },
+
+        accent: {
+          blue: '#3b82f6',
+          purple: '#8b5cf6',
+          indigo: '#6366f1',
+        },
+      },
+
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+      },
+
+      fontSize: {
+        xs: ['12px', { lineHeight: '16px' }],
+        sm: ['14px', { lineHeight: '20px' }],
+        base: ['16px', { lineHeight: '24px' }],
+        lg: ['18px', { lineHeight: '28px' }],
+        xl: ['20px', { lineHeight: '28px' }],
+        '2xl': ['24px', { lineHeight: '32px' }],
+        '3xl': ['30px', { lineHeight: '36px' }],
+        '4xl': ['36px', { lineHeight: '40px' }],
+        '5xl': ['48px', { lineHeight: '1' }],
+      },
+
+      spacing: {
+        0.5: '2px',
+        1: '4px',
+        1.5: '6px',
+        2: '8px',
+        3: '12px',
+        4: '16px',
+        5: '20px',
+        6: '24px',
+        8: '32px',
+        10: '40px',
+        12: '48px',
+        16: '64px',
+        20: '80px',
+        24: '96px',
+      },
+
+      borderRadius: {
+        sm: '6px',
+        DEFAULT: '8px',
+        md: '12px',
+        lg: '16px',
+        xl: '20px',
+        '2xl': '24px',
+        '3xl': '32px',
+        full: '9999px',
+      },
+
+      boxShadow: {
+        xs: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+        sm: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+        DEFAULT: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+        md: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+        lg: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+        xl: '0 25px 50px -12px rgb(0 0 0 / 0.25)',
+        '2xl': '0 25px 50px -12px rgb(0 0 0 / 0.25)',
+        inner: 'inset 0 2px 4px 0 rgb(0 0 0 / 0.05)',
+      },
+
+      fontWeight: {
+        normal: '400',
+        medium: '450',
+        semibold: '500',
+        bold: '700',
+      },
+    },
   },
   plugins: [],
 };

--- a/utils/cn.ts
+++ b/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
This patch introduces a set of reusable UI components and a utility function to standardize styling, improve maintainability, and streamline navigation.

Changes:

* New UI components
  * `Button`: supports variants, sizes, loading state, icons, and disabled state.
  * `Card`: flexible container with variants (default, elevated, bordered), padding, and optional press handling.
  * `Input`: includes label, error, hint, and focus state styling.
  * `Typography`: provides consistent heading, body, and caption text styles.

* Utility
  * Add `cn` function (`utils/cn.ts`) for conditional class name concatenation.

* Navigation
  * Remove `transaction/[id]` and `category-select` modal screens from stack (`app/_layout.tsx`).