### PR TITLE
chore(github): add configs for ownership, funding, dependabot, and CodeQL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Main code owner
+* @totallynotdavid

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [totallynotdavid]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: 'pip'
+  - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'app/**'
+      - 'src/**'
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'src/**'
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This patch introduces GitHub configuration files to improve repository management, automation, and security.

Repository management and ownership:
* Add .github/CODEOWNERS to assign @totallynotdavid as repository maintainer
* Add .github/FUNDING.yml to enable sponsorship for @totallynotdavid

Automation and security:
* Add .github/dependabot.yml to configure automated dependency updates for Python (daily) and GitHub Actions (weekly)
* Add .github/workflows/codeql.yml to enable CodeQL analysis of JavaScript code under app and src on push, PR, and weekly schedule