### PR TITLE
chore(dev): pin Node.js version and add developer task scripts

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,35 @@
 [tools]
-node = "24"
+node = "24.6.0"
+
+[tasks.setup]
+description = "Complete project setup for new developers"
+run = [
+    "npm install",
+    "mise run dev",
+]
+
+[tasks.dev]
+description = "Start development server with cache clearing"
+run = "npx expo start"
+alias = "d"
+
+[tasks.reset]
+description = "Reset development environment (clear cache, reinstall)"
+run = [
+    "npm run format",
+    "rm -rf node_modules",
+    "rm -rf .expo",
+    "npm install",
+    "npx expo install --fix",
+]
+
+[tasks.build-preview]
+description = "Build preview version using EAS"
+run = "npx eas build -p android --profile preview"
+
+[tasks.doctor]
+description = "Run Expo doctor to check for common issues"
+run = [
+    "npx expo-doctor",
+    "npx expo install --check",
+]


### PR DESCRIPTION
This patch updates the project environment to improve consistency and streamline
developer workflows.

* Environment
  * Pin Node.js version in mise.toml from "24" to "24.6.0" for reproducible
    setups across systems.

* Developer tasks
  * Add task scripts in mise.toml for:
    * setup         initialize environment
    * dev           start development server
    * reset         reset environment
    * build-preview build preview version
    * doctor        run diagnostic checks